### PR TITLE
fix: environment variable satellite ID

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import { getDetailUser, setIdentityAsUser } from "@/server/users.service";
 
 import config from "@/config";
 
-if (config.sateliteId === undefined) {
+if (config.satelliteId === undefined) {
   throw new Error("Satellite ID is not defined");
 }
 
@@ -24,7 +24,7 @@ export default function Home() {
   useEffect(() => {
     (async () =>
       await initSatellite({
-        satelliteId: config.sateliteId,
+        satelliteId: config.satelliteId,
         workers: {
           auth: true
         }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,13 +1,13 @@
 import CryptoJS from "crypto-js";
 
 interface ConfigProps {
-  sateliteId: string | undefined;
+  satelliteId: string | undefined;
   encKey: CryptoJS.lib.WordArray;
   encIV: CryptoJS.lib.WordArray;
 }
 
 const CONFIG: ConfigProps = {
-  sateliteId: process.env.NEXT_PUBLIC_APP_SATELITE_ID,
+  satelliteId: process.env.NEXT_PUBLIC_SATELLITE_ID,
   encKey: CryptoJS.enc.Hex.parse(process.env.NEXT_PUBLIC_APP_ENC_KEY || "x"),
   encIV: CryptoJS.enc.Hex.parse(process.env.NEXT_PUBLIC_APP_ENV_IV || "x")
 };


### PR DESCRIPTION
There was a typo in the usage of the environment variable injected by the Juno NextJS plugin.

Instead of `NEXT_PUBLIC_APP_SATELITE_ID` -> `NEXT_PUBLIC_SATELLITE_ID`.

In this PR, not an issue, but I corrected a typo `sateliteId` -> `satelliteId`.