### PR TITLE
chore: config satellite ID

### DIFF
--- a/juno.config.ts
+++ b/juno.config.ts
@@ -1,13 +1,8 @@
 import {defineConfig} from "@junobuild/config";
-import CONFIG from "./src/config";
-
-if (!CONFIG.sateliteId) {
-  throw new Error("Satelite ID is required");
-}
 
 export default defineConfig({
   satellite: {
-    id: CONFIG.sateliteId,
+    id: "REPLACE-WITH-YOUR-SATELLITE-ID",
     source: "out"
   }
 });


### PR DESCRIPTION
The `juno.config.ts` should contains your effective Satellite ID. You can find the ID in the https://console.juno.build.

So this PR just edit the config, removing a recursive imports, and add a placeholder.